### PR TITLE
Webアプリ開発4-2（修正）

### DIFF
--- a/webAppliDevelop/sql/sql.txt
+++ b/webAppliDevelop/sql/sql.txt
@@ -7,7 +7,7 @@
 
 
 CREATE TABLE counter_table (
-	key   int(3) NOT NULL,
+	counter_id int(3) NOT NULL,
 	count int(5) NOT NULL,
-	PRIMARY KEY (key)
+	PRIMARY KEY (counter_id)
 )


### PR DESCRIPTION
create table文を実行したところエラー（※）となりました。エラーの原因は、カラム名に使おうとした「key」という単語が予約語だからだと考えており、カラム名を修正しました。

先日レビューしていただいた後プルリクをマージしてしまったので、プルリクを再度提出いたします。すみませんがご確認のほどお願いいたします。

（※）エラー内容
SQL   : #42000You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'int(3) NOT NULL,
	count int(5) NOT NULL,
	PRIMARY KEY (key)
)' at line 2
