### PR TITLE
Webアプリ開発2　9-1.ＤＢ接続していない状態で登録したあとボタンを押しても登録ダイアログが表示されない対応。

### DIFF
--- a/webAppliDevelop2/src/view/BookApp.vue
+++ b/webAppliDevelop2/src/view/BookApp.vue
@@ -255,7 +255,7 @@ export default {
               )
               .withFailureHandler(
                 // selectBooksAllが異常終了したら、空情報を設定してから、rejectする。（例外発生となる。）
-                (error) => { this.bookRecords = this.initBookInfo; reject(error);  }
+                (error) => { this.bookRecords = []; reject(error);  }
               )
               .selectAllBooks()
           }
@@ -289,7 +289,7 @@ export default {
                 (bookRecords) => { this.bookRecords = bookRecords; resolve(); }
               )
               .withFailureHandler(
-                (error) => { this.bookRecords = this.initBookInfo; reject(error);  }
+                (error) => { this.bookRecords = []; reject(error);  }
               )
               .selectSearchedBooks(this.searchText, this.searchType)
           }


### PR DESCRIPTION
過去に指摘いただいたエラー時の挙動で、機能に直接関係がないため対応を後回しにしていたものを、対応しました。
ご確認のほどお願いいたします。

過去の指摘 … https://github.com/nosenami/tutorial/pull/25#issuecomment-1702668591

<img width="2171" alt="20240331nose" src="https://github.com/nosenami/tutorial/assets/67619203/91113dd3-df16-4b4f-8ca8-269d507a8fb6">

【挙動の変更点】

登録入力画面にて「この書籍情報で登録する」ボタン押下する
↓
（DBの接続が切れているなどで）登録に失敗
↓
登録ができなかった旨のアラート表示される
↓
一覧画面が表示される
↓
「登録する」ボタンを押下
する。
　対応前：「登録する」ボタンを押しても、反応がない。
　対応後：「登録する」ボタンを押して、反応がある。（登録入力画面が表示される。）

【アプリ原因】

v-data-tableタグで、一覧の明細にあたる変数「bookRecords」には配列を設定するべきでしたが、
エラー時に、「bookRecords」に配列ではなくオブジェクトを設定していたため、
v-data-tableタグが正常に動作していなかったと思われます。

